### PR TITLE
:bug: Fix response to `\r` command

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -235,6 +235,10 @@ void handle_command(hal::serial& p_serial,
       handled = version_command(p_serial);
       break;
     }
+    case '\r': {
+      handled = true;
+      break;
+    }
   }
 
   if (not open) {
@@ -431,7 +435,7 @@ int main()
     }
 
     red_led.level(false);
-    hal::delay(clock, 250ms);
+    hal::delay(clock, 1ms);
   }
 
   return 0;


### PR DESCRIPTION
A command is allowed to be just a `\r` which allows an application to see if the device is responsive and awake.